### PR TITLE
adding Iam changes

### DIFF
--- a/serverless/deploy-serverless-permission-boundary.sh
+++ b/serverless/deploy-serverless-permission-boundary.sh
@@ -1,2 +1,7 @@
 # Deploy the global permission boundary.
-aws cloudformation deploy --stack-name=serverless-permission-boundary --template-file=serverless-permission-boundary.yaml --capabilities=CAPABILITY_NAMED_IAM --region=eu-west-1
+aws cloudformation deploy \
+--stack-name=serverless-permission-boundary \
+--template-file=serverless-permission-boundary.yaml  \
+--capabilities=CAPABILITY_NAMED_IAM  \
+--region=eu-west-1 \
+--parameter-overrides Squad=MySquad

--- a/serverless/deploy-squad-ci-user.sh
+++ b/serverless/deploy-squad-ci-user.sh
@@ -1,2 +1,7 @@
 # Deploy the template for a squad.
-aws cloudformation deploy --stack-name=squad-ci-user-mysquad --template-file=./squad-ci-user.yaml --capabilities=CAPABILITY_NAMED_IAM --region=eu-west-1 --parameter-overrides Squad=MySquad
+aws cloudformation deploy \
+--stack-name=squad-ci-user-mysquad \
+--template-file=./squad-ci-user.yaml \
+--capabilities=CAPABILITY_NAMED_IAM \
+--region=eu-west-1 \
+--parameter-overrides Squad=MySquad

--- a/serverless/serverless-permission-boundary.yaml
+++ b/serverless/serverless-permission-boundary.yaml
@@ -1,6 +1,10 @@
 ---
 # Global CI/CD permission boundary and Serverless deployment bucket per AWS account.
 AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  Squad:
+    Type: String
+    Description: The name of the squad that this permission boundary is for. This ensures that each squad's CI user can only affect their own work.
 Resources:
   # PermissionBoundary has an explicit deny all. The boundary sets the maximum set of permissions.
   ServerlessPermissionBoundary:
@@ -18,35 +22,63 @@ Resources:
               - iam:SimulatePrincipalPolicy
             Resource:
               - "*"
+          # These are for serverless services that need a * in resources as we do not know
+          # the exact path of in advance e.g. api gateway. 
           - Sid: AllowServerlessServices
             Effect: Allow
             Action:
               - apigateway:*
               - cloudwatch:*
-              - cognito-idp:*
-              - dynamodb:*
+              - events:*
+              - logs:*
+              - states:*
+              - xray:*
               - ec2:CreateNetworkInterface
               - ec2:DeleteNetworkInterface
-              - ec2:Describe*
-              - events:*
-              - kms:*
-              - lambda:*
-              - logs:*
-              - s3:*
-              - schemas:*
-              - sns:*
-              - sqs:*
-              - ssm:*
-              - states:*
-              - synthetics:*
-              - xray:*
+              - ec2:Describe* 
+              # Other services to consider and write more granular restrictions for.
+              # - schemas:*
+              # - sns:*
+              # - sqs:*
+              # - kms:*
+              # - synthetics:*
             Resource:
               - "*"
             Condition:
               StringEquals:
                 aws:RequestedRegion:
                   - us-east-1 # Allow North Virginia for CloudFront.
-                  - eu-west-1 # Europe.
+                  - eu-west-2 # Europe.              
+          - Sid: AllowS3
+            Effect: Allow 
+            Action: 
+              - s3:*
+            Resource: 
+              - !Sub arn:aws:s3:::${Squad}*
+          - Sid: AllowLambda
+            Effect: Allow 
+            Action: 
+              - lambda:*
+            Resource: 
+              - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${Squad}*              
+          - Sid: AllowDynamo
+            Effect: Allow 
+            Action: 
+              - dynamodb:*
+            Resource: 
+              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${Squad}*   
+          - Sid: AllowSecretsManagerGetOnly
+            Effect: Allow 
+            Action: 
+              - secretsmanager:GetSecretValue
+            Resource: 
+              - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${Squad}*                          
+          - Sid: AllowSSMParameters
+            Effect: Allow 
+            Action: 
+              - ssm:*
+            Resource: 
+              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter:${Squad}*                                
           - Sid: DenyDynamoRowLevelActions
             Effect: Deny
             Action:
@@ -67,6 +99,7 @@ Resources:
               - cloudformation:CreateStack
               - cloudformation:DescribeStackEvents
               - cloudformation:DescribeStackResources
+              - cloudformation:DescribeStackResource
               - cloudformation:DescribeStacks
               - cloudformation:GetTemplate
               - cloudformation:ListStackResources
@@ -74,18 +107,28 @@ Resources:
               - cloudformation:ValidateTemplate
               - cloudformation:DeleteStack
             Resource:
-              - "*"
+              - !Sub arn:aws:cloudformation:*:${AWS::AccountId}:stack/${Squad}-*
             Condition:
               StringEquals:
                 aws:RequestedRegion:
                   - us-east-1 # Allow North Virginia for CloudFront.
                   - eu-west-1 # Europe.
+          - Sid: AllowValidationOfAnyStack
+            Effect: Allow
+            Action:
+              - cloudformation:ValidateTemplate
+            Resource:
+              - "*"
+            Condition:
+              StringEquals:
+                aws:RequestedRegion:
+                  - eu-west-2 # Europe.                                
           - Sid: AllowPassRoleToLambda
             Effect: Allow
             Action:
               - iam:PassRole
             Resource:
-              - arn:aws:iam:::role/*
+              - !Sub arn:aws:iam::${AWS::AccountId}:role/${Squad}*
             Condition:
               StringEquals:
                 iam:PassedToService: lambda.amazonaws.com
@@ -97,7 +140,7 @@ Resources:
               - iam:DeletePolicyVersion
               - iam:SetDefaultPolicyVersion
             Resource:
-              - arn:aws:iam:::policy/serverless-permission-boundary
+              - !Sub arn:aws:iam::${AWS::AccountId}:policy/${Squad}-permissions-boundary
           - Sid: ExplicitDenyRemovalOfPermBoundaryFromAnyRole
             Effect: Deny
             Action:
@@ -106,7 +149,7 @@ Resources:
               - arn:aws:iam:::role/*
             Condition:
               StringEquals:
-                iam:PermissionsBoundary: arn:aws:iam:::policy/serverless-permission-boundary
+                iam:PermissionsBoundary: !Sub arn:aws:iam::${AWS::AccountId}:policy/${Squad}-permissions-boundary
           - Sid: AllowUpsertRoleIfPermBoundaryIsBeingApplied
             Effect: Allow
             Action:
@@ -114,18 +157,19 @@ Resources:
               - iam:PutRolePolicy
               - iam:PutRolePermissionsBoundary
             Resource:
-              - "*"
+              - !Sub arn:aws:iam::${AWS::AccountId}:policy/${Squad}-*
+              - !Sub arn:aws:iam::${AWS::AccountId}:role/${Squad}-*
             Condition:
               StringEquals:
-                # The permission boundary needs to explitly provide the account.
-                iam:PermissionsBoundary: !Sub "arn:aws:iam:${AWS::AccountId}:policy/serverless-permission-boundary"
+                # The permission boundary needs to explicitly provide the account.
+                iam:PermissionsBoundary: !Sub arn:aws:iam::${AWS::AccountId}:policy/${Squad}-permissions-boundary
           - Sid: AllowDeleteRole
             Effect: Allow
             Action:
               - iam:DeleteRolePolicy
               - iam:DeleteRole
             Resource:
-              - "*"
+              - !Sub arn:aws:iam::${AWS::AccountId}:role/${Squad}-*
 
   # Instead of using Serverless Framework to create a bucket, create your own so that we can control the policy more carefully.
   # This also reduces the number of buckets that are lying around.

--- a/serverless/serverless-permission-boundary.yaml
+++ b/serverless/serverless-permission-boundary.yaml
@@ -48,7 +48,7 @@ Resources:
               StringEquals:
                 aws:RequestedRegion:
                   - us-east-1 # Allow North Virginia for CloudFront.
-                  - eu-west-2 # Europe.              
+                  - eu-west-1 # Europe.              
           - Sid: AllowS3
             Effect: Allow 
             Action: 

--- a/serverless/serverless-permission-boundary.yaml
+++ b/serverless/serverless-permission-boundary.yaml
@@ -36,12 +36,12 @@ Resources:
               - ec2:CreateNetworkInterface
               - ec2:DeleteNetworkInterface
               - ec2:Describe* 
-              # Other services to consider and write more granular restrictions for.
-              # - schemas:*
-              # - sns:*
-              # - sqs:*
-              # - kms:*
-              # - synthetics:*
+              # You might want to consider limiting squads to more granular restrictions for these services at the permission boundary level, depending on your use case.
+              - schemas:*
+              - sns:*
+              - sqs:*
+              - kms:*
+              - synthetics:*
             Resource:
               - "*"
             Condition:

--- a/serverless/serverless-permission-boundary.yaml
+++ b/serverless/serverless-permission-boundary.yaml
@@ -122,7 +122,7 @@ Resources:
             Condition:
               StringEquals:
                 aws:RequestedRegion:
-                  - eu-west-2 # Europe.                                
+                  - eu-west-1 # Europe.
           - Sid: AllowPassRoleToLambda
             Effect: Allow
             Action:

--- a/serverless/serverless-permission-boundary.yaml
+++ b/serverless/serverless-permission-boundary.yaml
@@ -79,6 +79,12 @@ Resources:
               - ssm:*
             Resource: 
               - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter:${Squad}*                                
+          - Sid: AllowCognito
+            Effect: Allow 
+            Action: 
+              - cognito-idp:*
+            Resource: 
+              - !Sub arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/:${Squad}*                                  
           - Sid: DenyDynamoRowLevelActions
             Effect: Deny
             Action:

--- a/serverless/squad-ci-user.yaml
+++ b/serverless/squad-ci-user.yaml
@@ -51,6 +51,7 @@ Resources:
             Action:
               - cloudformation:CreateStack
               - cloudformation:DescribeStackEvents
+              - cloudformation:DescribeStackResource
               - cloudformation:DescribeStackResources
               - cloudformation:DescribeStacks
               - cloudformation:GetTemplate
@@ -59,7 +60,13 @@ Resources:
               - cloudformation:ValidateTemplate
               - cloudformation:DeleteStack
             Resource: # Only allow user permission to modify their own namespace.
-              - !Sub arn:aws:cloudformation:::stack/${Squad}-*
+              - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${Squad}-*
+          - Sid: AllowCloudformationValidationOnEverything
+            Effect: Allow
+            Action:
+              - cloudformation:ValidateTemplate
+            Resource:
+              - "*"              
           - Sid: AllowS3ListBucketOnServerlessBucket
             Effect: Allow
             Action:
@@ -77,7 +84,7 @@ Resources:
               - s3:ListBucket
             Resource:
               - Fn::Sub:
-                - arn:aws:s3:::${ServerlessDeploymentBucket}
+                - arn:aws:s3:*:*:${ServerlessDeploymentBucket}
                 - ServerlessDeploymentBucket: !ImportValue ServerlessDeploymentBucket
           - Sid: AllowS3PutObjectOnServerlessBucket
             Effect: Allow
@@ -97,7 +104,7 @@ Resources:
               - lambda:CreateFunction
               - lambda:DeleteFunction
             Resource:
-              - !Sub arn:aws:lambda:::function:${Squad}-*
+              - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${Squad}-*       
           - Sid: AllowLambdaIAMRoleCreation
             Effect: Allow
             Action:
@@ -107,13 +114,19 @@ Resources:
               - iam:DeleteRolePolicy
               - iam:DeleteRole
             Resource:
-              - !Sub arn:aws:iam:::role/${Squad}-*
+              - !Sub arn:aws:iam::${AWS::AccountId}:role/${Squad}-*
+          - Sid: AllowAnyGetRole
+            Effect: Allow
+            Action:
+              - iam:GetRole
+            Resource:
+              - "*"              
           - Sid: AllowPassRoleToLambda
             Effect: Allow
             Action:
               - iam:PassRole
             Resource:
-              - !Sub arn:aws:iam:::role/${Squad}-*
+              - !Sub arn:aws:iam::${AWS::AccountId}:role/${Squad}-*
             Condition:
               StringEquals:
                 iam:PassedToService: lambda.amazonaws.com
@@ -128,7 +141,7 @@ Resources:
               - lambda:RemovePermission
               - lambda:Update*
             Resource:
-              - !Sub arn:aws:lambda:::function:${Squad}-*
+              - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${Squad}-*
           - Sid: AllowLogGroupCreation
             Effect: Allow
             Action:
@@ -150,6 +163,17 @@ Resources:
               - arn:aws:apigateway:*::/restapis*
               - arn:aws:apigateway:*::/apikeys*
               - arn:aws:apigateway:*::/usageplans
+              - arn:aws:apigateway:*::/tags*
+          - Sid: AllowCloudWatchEvents 
+            Effect: Allow
+            Action:
+              - events:PutRule
+              - events:DescribeRule
+              - events:PutTargets
+              - events:EnableRule
+              - events:TestEventPattern
+            Resource:
+              - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/${Squad}-*              
 
 Outputs:
   UserName:


### PR DESCRIPTION
Add more privileges to the ci user to be able create a serverless stack including cloudwatch events 

Adding the region and account ID to the Iam resources where it is needed 

Adding more lockdown to the permissions boundary to limit changes to the squads name and again fix the accountID and region. 